### PR TITLE
Add support for child component and small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ This child component will receive the `message`, `warning` and `error` props pas
 Default value: `null`.
 Example:
 ```jsx
-<Toast messageStyle={{ color: 'white' }}>
-  <Text>I'm a toast!</Text>
+const CustomMessageComponent = ({ text }) => <Text style={{ color: 'red' }}>{text}</Text>;
+
+<Toast messageStyle={{ color: 'white' }} message>
+  {({ message }) => <CustomMessageComponent text={message}/>}
 </Toast>
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ Toast.defaultProps = {
 };
 ```
 
+- **children:** (React.PropTypes.element)
+Instead of passing a `getMessageComponent` function, you can pass a child component, which will be used to render the message.
+This child component will receive the `message`, `warning` and `error` props passed to the Toast component.
+Default value: `null`.
+Example:
+```jsx
+<Toast messageStyle={{ color: 'white' }}>
+  <Text>I'm a toast!</Text>
+</Toast>
+```
+
 ## Contributing
 
 1. Fork it

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-redux-toast",
   "version": "1.0.0",
   "description": "Cross platform implementation of Android's toast component. Easy to customize and integrate with redux. 100% written in JS.",
-  "main": "lib/index.js",
+  "main": "index.js",
   "scripts": {
     "lint": "eslint src && eslint index.js",
     "test": "jest",

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -51,6 +51,18 @@ export default class Toast extends Component {
     });
   }
 
+  _getMessageComponent() {
+    const propsForChild = {
+      error: this.state.error,
+      warning: this.state.warning
+    };
+
+    if (this.props.children) {
+      return React.cloneElement(this.props.children, { message: this.state.message, ...propsForChild });
+    }
+    return this.props.getMessageComponent(this.state.message, propsForChild);
+  }
+
   render() {
     if (!this.state.present) {
       return null;
@@ -71,10 +83,7 @@ export default class Toast extends Component {
         ]}
       >
         <View style={messageStyles}>
-          {this.props.getMessageComponent(this.state.message, {
-            error: this.state.error,
-            warning: this.state.warning
-          })}
+          {this._getMessageComponent()}
         </View>
       </Animated.View>
     );
@@ -100,5 +109,6 @@ Toast.propTypes = {
   warning: React.PropTypes.bool,
   warningStyle: View.propTypes.style,
   duration: React.PropTypes.number,
-  getMessageComponent: React.PropTypes.func
+  getMessageComponent: React.PropTypes.func,
+  children: React.PropTypes.element
 };

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -1,8 +1,8 @@
 export const actions = {
-  DISPLAY_ERROR: Symbol('DISPLAY_ERROR'),
-  DISPLAY_WARNING: Symbol('DISPLAY_WARNING'),
-  DISPLAY_INFO: Symbol('DISPLAY_INFO'),
-  HIDE: Symbol('HIDE'),
+  DISPLAY_ERROR: '@@TOAST/DISPLAY_ERROR',
+  DISPLAY_WARNING: '@@TOAST/DISPLAY_WARNING',
+  DISPLAY_INFO: '@@TOAST/DISPLAY_INFO',
+  HIDE: '@@TOAST/HIDE',
 };
 
 const toastAction = (message, duration, type) => ({

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -1,8 +1,8 @@
 export const actions = {
-  DISPLAY_ERROR: '@@TOAST/DISPLAY_ERROR',
-  DISPLAY_WARNING: '@@TOAST/DISPLAY_WARNING',
-  DISPLAY_INFO: '@@TOAST/DISPLAY_INFO',
-  HIDE: '@@TOAST/HIDE'
+  DISPLAY_ERROR: Symbol('DISPLAY_ERROR'),
+  DISPLAY_WARNING: Symbol('DISPLAY_WARNING'),
+  DISPLAY_INFO: Symbol('DISPLAY_INFO'),
+  HIDE: Symbol('HIDE'),
 };
 
 const toastAction = (message, duration, type) => ({


### PR DESCRIPTION
- Adds support for passing a child component to use as messageComponent:
```jsx
<Toast messageStyle={{ color: 'white' }}>
  <Text>I'm a toast!</Text>
</Toast>
```

- Use ES6 symbols instead of weird string constants with for action names (symbols provide an unique identifier which solves the name-collision problem, without having to prefix constants with stuff like `@@toast/`).

- Fixes mistake in path in `package.json`.