### PR TITLE
Migrate to new prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/Wolox/react-native-redux-toast",
   "dependencies": {
+    "prop-types": "^15.5.10",
     "seamless-immutable": "^7.1.2"
   },
   "devDependencies": {

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View, Animated, Text } from 'react-native';
 
 import styles from './Toast.styles';
@@ -93,12 +94,12 @@ Toast.defaultProps = {
 
 Toast.propTypes = {
   containerStyle: View.propTypes.style,
-  message: React.PropTypes.string,
+  message: PropTypes.string,
   messageStyle: Text.propTypes.style, // eslint-disable-line react/no-unused-prop-types
-  error: React.PropTypes.bool,
+  error: PropTypes.bool,
   errorStyle: View.propTypes.style,
-  warning: React.PropTypes.bool,
+  warning: PropTypes.bool,
   warningStyle: View.propTypes.style,
-  duration: React.PropTypes.number,
-  getMessageComponent: React.PropTypes.func
+  duration: PropTypes.number,
+  getMessageComponent: PropTypes.func
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3653,6 +3653,13 @@ prop-types@^15.0.0, prop-types@^15.5.7:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"


### PR DESCRIPTION
Using `React.PropTypes` throws a warning, and the [prop-types](https://github.com/facebook/prop-types) package should be used instead. 