### PR TITLE
feat(Toast): add position props, to change the position of the toast fix #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ Toast.defaultProps = {
 };
 ```
 
+- **position:** (React.PropTypes.number)
+The position of toast and it must be a number. If it's set greater than 0, the position will be on top with that value. if it's not specified, the default is -100 and will transform to 100 in the render function and the position will be on bottom with that value. for instance:
+```js
+  <Toast
+    position={50} // equivalent { top: 50 }
+    messageStyle={{ color: Colors.snow }}
+    containerStyle={{ backgroundColor: Colors.primary }}
+  />
+```
+
 ## Contributing
 
 1. Fork it

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "coverage": "jest --coverage",
     "build": "babel index.js -d lib && babel src -d lib/src",
     "prepublish": "npm run build",
+    "preinstall": "npm i -g babel-cli",
     "postinstall": "npm run build",
     "lint-diff": "git diff --name-only --cached --relative | grep \\\\.js$ | xargs eslint",
     "precommit": "npm run lint-diff"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "coverage": "jest --coverage",
     "build": "babel index.js -d lib && babel src -d lib/src",
     "prepublish": "npm run build",
+    "postinstall": "npm run build",
     "lint-diff": "git diff --name-only --cached --relative | grep \\\\.js$ | xargs eslint",
     "precommit": "npm run lint-diff"
   },


### PR DESCRIPTION
in the response to issue #5 , I create a solution for it.
usage for instance:
```jsx
  <Toast
     position={50}
     messageStyle={{ color: Colors.snow }}
     containerStyle={{ backgroundColor: Colors.primary }}
   />
```
the position must be an integer. If it's set greater than 0, the position will be on top with that value. if it's not specified, the default is -100 and will transform to 100  in the render function and the position will be on bottom with that value.
@sbalay, what about your opinion?

thanks.